### PR TITLE
Update Prism and GetPage using new WindowManager.Current

### DIFF
--- a/Popups.Maui.Prism/Dialogs/PopupPageDialogService.cs
+++ b/Popups.Maui.Prism/Dialogs/PopupPageDialogService.cs
@@ -191,7 +191,7 @@ namespace Popups.Maui.Prism.Dialogs
 
         private Page GetPage()
         {
-            if (this.WindowManager.Windows.FirstOrDefault() is not { } window)
+            if (this.WindowManager.Current is not PrismWindow window)
             {
                 throw new InvalidOperationException("There is no Prism Window currently displayed.");
             }

--- a/Popups.Maui.Prism/Popups.Maui.Prism.csproj
+++ b/Popups.Maui.Prism/Popups.Maui.Prism.csproj
@@ -50,7 +50,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Mopups" Version="1.3.1" />
-		<PackageReference Include="Prism.Maui" Version="9.0.537" />
+		<PackageReference Include="Prism.Maui" Version="[9.0.537,)" />
 	</ItemGroup>
 	
 	<ItemGroup Condition="$(TargetFramework.Contains('net8.0'))">

--- a/Popups.Maui.Prism/Popups.Maui.Prism.csproj
+++ b/Popups.Maui.Prism/Popups.Maui.Prism.csproj
@@ -50,7 +50,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Mopups" Version="1.3.1" />
-		<PackageReference Include="Prism.Maui" Version="[9.0.401-pre,)" />
+		<PackageReference Include="Prism.Maui" Version="9.0.537" />
 	</ItemGroup>
 	
 	<ItemGroup Condition="$(TargetFramework.Contains('net8.0'))">

--- a/Popups.Maui/Popups.Maui.csproj
+++ b/Popups.Maui/Popups.Maui.csproj
@@ -34,11 +34,14 @@
 		<RepositoryUrl>https://github.com/thomasgalliker/MauiPopups</RepositoryUrl>
 		<Company>superdev GmbH</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-		<PackageReleaseNotes>1.1
-- Add PopupDialogService to intercept Prism's popup handling
+		<PackageReleaseNotes>1.2
+- Update GetPage method to use WindowManager.Current.
+
+1.1
+- Add PopupDialogService to intercept Prism's popup handling.
 
 1.0
-- Initial release
+- Initial release.
 		</PackageReleaseNotes>
 		<Copyright>Copyright $([System.DateTime]::Now.ToString(`yyyy`)) © Thomas Galliker</Copyright>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Samples/MauiSampleApp/MauiSampleApp.csproj
+++ b/Samples/MauiSampleApp/MauiSampleApp.csproj
@@ -5,7 +5,7 @@
 		<OutputType>Exe</OutputType>
 		<RootNamespace>MauiSampleApp</RootNamespace>
 		<UseMaui>true</UseMaui>
-        <MauiVersion>8.0.70</MauiVersion>
+    <MauiVersion>8.0.72</MauiVersion>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>disable</Nullable>
@@ -55,7 +55,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
 		<PackageReference Include="Mopups" Version="1.3.1" />
-		<PackageReference Include="Prism.DryIoc.Maui" Version="9.0.401-pre" />
+		<PackageReference Include="Prism.DryIoc.Maui" Version="9.0.537" />
 		<PackageReference Include="ValueConverters.MAUI" Version="3.0.26" />
     
     <!--To avoid silly build errors... incredible!-->

--- a/Tests/Popups.Maui.Tests/Popups.Maui.Tests.csproj
+++ b/Tests/Popups.Maui.Tests/Popups.Maui.Tests.csproj
@@ -13,7 +13,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Maui.Essentials" Version="8.0.7" />
+		<PackageReference Include="Microsoft.Maui.Essentials" Version="8.0.72" />
 		<PackageReference Include="Moq" Version="4.18.4" />
 		<PackageReference Include="Moq.AutoMock" Version="3.5.0" />
 		<PackageReference Include="FluentAssertions" Version="6.12.0" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
   majorVersion: 1
-  minorVersion: 1
+  minorVersion: 2
   patchVersion: $[counter(format('{0}.{1}', variables.majorVersion, variables.minorVersion), 0)]
   ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
     # Versioning: 1.0.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,10 +12,7 @@ pool:
 trigger:
   branches:
     include:
-    - main
-    - develop
-    - feature/*
-    - bugfix/*
+    - refs/heads/*
 
   paths:
     exclude:


### PR DESCRIPTION
I have some error in my app coming from MauiPopups which saying `There is no Prism Window currently displayed.` (can't replicate actually). These changes make sure to use latest stable prism so we can make it more reliable.

- Update prism to 9.0.537 (stable)
- `GetPage` now using `WindowManager.Current` so it have the same code with [Prism](https://github.com/PrismLibrary/Prism/blob/master/src/Maui/Prism.Maui/Services/PageDialogs/PageDialogService.cs#L185-L186)
- Update `Microsoft.Maui.Essentials` to 8.0.72 so it all the same to use 8.0.72 for the MAUI base