### PR TITLE
Handle NullReferenceException if Handler not yet ready

### DIFF
--- a/Popups.Maui.Prism/Popups.Maui.Prism.csproj
+++ b/Popups.Maui.Prism/Popups.Maui.Prism.csproj
@@ -49,7 +49,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Mopups" Version="1.3.1" />
+		<PackageReference Include="Mopups" Version="[1.3.2,)" />
 		<PackageReference Include="Prism.Maui" Version="[9.0.537,)" />
 	</ItemGroup>
 	

--- a/Popups.Maui/Extensions/MauiAppBuilderExtensions.cs
+++ b/Popups.Maui/Extensions/MauiAppBuilderExtensions.cs
@@ -1,10 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Maui.LifecycleEvents;
-using Mopups.Pages;
+using Mopups.Hosting;
 using Mopups.Services;
-#if IOS
-using Mopups.Platforms.iOS;
-#endif
 
 namespace Popups.Maui
 {
@@ -15,26 +11,7 @@ namespace Popups.Maui
         /// </summary>
         public static MauiAppBuilder UseMauiPopups(this MauiAppBuilder builder)
         {
-            //builder.ConfigureMopups();
-
-            builder.ConfigureLifecycleEvents(delegate (ILifecycleBuilder lifecycle)
-            {
-#if ANDROID        
-                lifecycle.AddAndroid(delegate (IAndroidLifecycleBuilder d)
-                {
-                    d.OnBackPressed((Android.App.Activity activity) =>
-                    {
-                        return Mopups.Droid.Implementation.AndroidMopups.SendBackPressed();
-                    });
-                });
-#endif
-            }).ConfigureMauiHandlers(delegate (IMauiHandlersCollection handlers)
-            {
-#if ANDROID || IOS
-                handlers.AddHandler(typeof(PopupPage), typeof(PopupPageHandler));
-#endif
-            });
-
+            builder.ConfigureMopups();
             builder.Services.TryAddSingleton(MopupService.Instance);
 
             return builder;

--- a/Popups.Maui/Popups.Maui.csproj
+++ b/Popups.Maui/Popups.Maui.csproj
@@ -56,7 +56,7 @@
 
 	<ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.0,)" />
-	  <PackageReference Include="Mopups" Version="[1.3.1,)" />
+	  <PackageReference Include="Mopups" Version="[1.3.2,)" />
 	</ItemGroup>
 	
 </Project>

--- a/Samples/MauiSampleApp/MauiSampleApp.csproj
+++ b/Samples/MauiSampleApp/MauiSampleApp.csproj
@@ -54,7 +54,7 @@
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-		<PackageReference Include="Mopups" Version="1.3.1" />
+		<PackageReference Include="Mopups" Version="1.3.2" />
 		<PackageReference Include="Prism.DryIoc.Maui" Version="9.0.537" />
 		<PackageReference Include="ValueConverters.MAUI" Version="3.0.26" />
     


### PR DESCRIPTION
In our application, we encounter an issue at the following GitHub link: https://github.com/LuckyDucko/Mopups/issues/118. Despite our efforts to reproduce it, we have been unable to do so. Consequently, we have decided to implement additional handling mechanisms to ensure the intended functionality is being achieved.
Additionally, the following updates have been made:
- Update to Mopups 1.3.2
- An unexpected error occurred when attempting to access the `Mopups.Platforms` namespace within the Mopups application. Despite the namespace being the same, the error message indicates that the namespace is not found. To resolve this issue, we have opted to use the `.ConfigureMopups()` method, as it provides the same functionality.