### PR TITLE
Fix logical condition for popping pages in navigation.

### DIFF
--- a/Popups.Maui.Prism/PopupPageNavigationService.cs
+++ b/Popups.Maui.Prism/PopupPageNavigationService.cs
@@ -80,7 +80,7 @@ namespace Popups.Maui.Prism
         protected override async Task<Page> DoPop(INavigation navigation, bool useModalNavigation, bool animated)
         {
             var page = this._pageAccessor.Page;
-            if (this.popupNavigation.PopupStack.Count > 0 || page is PopupPage)
+            if (this.popupNavigation.PopupStack.Count > 0 && page is PopupPage)
             {
                 await this.popupNavigation.PopAsync(animated);
                 return null;


### PR DESCRIPTION
Correct the condition by replacing 'or' with 'and' to ensure proper handling of popping pages only when a popup is active and on top of the stack. This prevents unintended behavior when managing popup navigation states.